### PR TITLE
patch: Remove sitemap plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "dependencies": {
         "@cmfcmf/docusaurus-search-local": "^0.11.0",
         "@docusaurus/core": "^2.2.0",
-        "@docusaurus/plugin-sitemap": "^2.2.0",
         "@docusaurus/preset-classic": "^2.2.0",
         "@mdx-js/react": "^1.6.22",
         "clsx": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
   "dependencies": {
     "@cmfcmf/docusaurus-search-local": "^0.11.0",
     "@docusaurus/core": "^2.2.0",
-    "@docusaurus/plugin-sitemap": "^2.2.0",
     "@docusaurus/preset-classic": "^2.2.0",
     "@mdx-js/react": "^1.6.22",
     "clsx": "^1.2.0",


### PR DESCRIPTION
Sitemap plugin already ships with theme preset-classic https://docusaurus.io/docs/seo#sitemap-file

Signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>
