### PR TITLE
patch: Replace URLs with enviroment variable

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -84,7 +84,7 @@ const config = {
           // right
           {
             href: '/changelog',
-            label: 'Change Log',
+            label: 'Changelog',
             position: 'right',
           },
           {
@@ -133,11 +133,11 @@ const config = {
             items: [
               {
                 label: 'GitHub',
-                href: '$REPO_URL',
+                href: process.env.REPO_URL,
               },
               {
                 label: 'Raise an issue',
-                href: '$REPO_URL/issues/new',
+                href: process.env.REPO_URL + '/issues/new',
               },
             ],
           },


### PR DESCRIPTION
Footer wasn't generating URLs due variables not working. Replaced them with environment variables.

Signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>
