### PR TITLE
patch: Redirect Changelog to external link

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -83,7 +83,7 @@ const config = {
         items: [
           // right
           {
-            href: '/changelog',
+            href: `${process.env.REPO_URL}/blob/${process.env.DEFAULT_BRANCH}/CHANGELOG.md`,
             label: 'Changelog',
             position: 'right',
           },

--- a/docusaurusify.sh
+++ b/docusaurusify.sh
@@ -13,7 +13,7 @@ echo "Chosen path for docs: $DOCS_PATH"
 cp -r $DOCS_PATH* /app/docs/
 
 # Move Changelog & README to docs build folder
-cp $GITHUB_WORKSPACE/CHANGELOG.md /app/docs/
+# cp $GITHUB_WORKSPACE/CHANGELOG.md /app/docs/
 ls -la /app/docs/
 cat $GITHUB_WORKSPACE/README.md >>/app/docs/README.md
 


### PR DESCRIPTION
Following the discussions here: https://balena.zulipchat.com/#narrow/stream/345882-_help/topic/Where.20are.20changelogs.20created.3F

I deem changelogs to be more trouble now than they are positvely worth. 

Signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>
