### PR TITLE
patch: Expand sed regex to catch more usecases

### DIFF
--- a/docusaurusify.sh
+++ b/docusaurusify.sh
@@ -18,7 +18,7 @@ ls -la /app/docs/
 cp $GITHUB_WORKSPACE/README.md /app/docs/README.md
 
 # Replace all links that have .docs/ in top level README as we flatten the dir structure
-sed -i 's/(.\/docs/(.\//g' /app/docs/README.md
+sed -i -r 's|\((\./)?docs/|\(\./|g' /app/docs/README.md
 
 # Replace logo file if it exits
 LOGO_PATH=$GITHUB_WORKSPACE/logo.png


### PR DESCRIPTION
Current sed implementation isn't working on balena-engine or open-balena README. So, I learned sed again today for the 50th time and came up with this. 

~Additionally while the round brackets will be helpful for markdown image tags, they won't do any good for HTML image tags~ On rechecking it seems Docusaurus can only understand markdown image tags so I guess we can make the sed command only change those. 

![Screenshot from 2022-12-06 20-55-06](https://user-images.githubusercontent.com/22801822/205957578-25e58bbb-9e06-4545-be1d-0de26c0c96f1.png)



Signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>
