### PR TITLE
patch: Delete sample README in theme

### DIFF
--- a/docs/.gitkeep
+++ b/docs/.gitkeep
@@ -2,6 +2,7 @@
 PROJECT_NAME: example name
 TAGLINE: example tagline
 ---
+
 # README
 
 This is a sample README file in the docs folder of our docusaurus template. If you see this deployed on your website, perhaps a README is missing in your repo.


### PR DESCRIPTION
Currently with there being a sample README in the docs always, the copy logic right now isn't copying the README inside the repo. Removing it will make everything work. 